### PR TITLE
Return `Square\TTCache\Result` when pre-loading cache entries

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Square\TTCache;
+
+/**
+ * Provides information about a cache retrieval that was performed.
+ */
+class Result
+{
+    /**
+     * @var array<string|int,string>
+     */
+    protected array $loadedKeys;
+
+    /**
+     * @var array<string|int,string>
+     */
+    protected array $missingKeys;
+    
+    /**
+     * @param array $loadedKeys
+     * @param array $missingKeys
+     */
+    public function __construct(array $loadedKeys, array $missingKeys)
+    {
+        $this->loadedKeys = $loadedKeys;
+        $this->missingKeys = $missingKeys;
+    }
+
+    /**
+     * @return array
+     */
+    public function loadedKeys(): array
+    {
+        return $this->loadedKeys;
+    }
+
+    /**
+     * @return array
+     */
+    public function missingKeys(): array
+    {
+        return $this->missingKeys;
+    }
+}

--- a/src/TTCache.php
+++ b/src/TTCache.php
@@ -180,17 +180,24 @@ class TTCache
      * Pre-loads a set of keys in the current node's local cache.
      * The preloaded data can be retrieved directly from memory from this node's
      * scope or any descendant node instead of going to the cache store.
+     *
+     * @param array $keys
+     * @return array
      */
-    public function load(array $keys)
+    public function load(array $keys): array
     {
+        $keys = array_combine($keys, $keys);
         $hkeys = array_map([$this, 'hashedKey'], $keys);
-
+        $hashToKeys = array_flip($hkeys);
+        $loadedKeys = [];
         $validValues = $this->cache->getMultiple($hkeys);
-        foreach ($validValues as $tv) {
+        foreach ($validValues as $k => $tv) {
+            $loadedKeys[] = $hashToKeys[$k];
             $this->rawTags(array_keys($tv->tags));
         }
         $this->tree->addToCache($validValues);
-    }
+        return $loadedKeys;
+    e
 
     /**
      * Applies a set of given tags without hashing them (useful for re-using tags directly)

--- a/src/TTCache.php
+++ b/src/TTCache.php
@@ -197,7 +197,7 @@ class TTCache
         }
         $this->tree->addToCache($validValues);
         return $loadedKeys;
-    e
+    }
 
     /**
      * Applies a set of given tags without hashing them (useful for re-using tags directly)

--- a/src/TTCache.php
+++ b/src/TTCache.php
@@ -182,9 +182,9 @@ class TTCache
      * scope or any descendant node instead of going to the cache store.
      *
      * @param array $keys
-     * @return array
+     * @return Result
      */
-    public function load(array $keys): array
+    public function load(array $keys): Result
     {
         $keys = array_combine($keys, $keys);
         $hkeys = array_map([$this, 'hashedKey'], $keys);
@@ -192,11 +192,13 @@ class TTCache
         $loadedKeys = [];
         $validValues = $this->cache->getMultiple($hkeys);
         foreach ($validValues as $k => $tv) {
-            $loadedKeys[] = $hashToKeys[$k];
+            $originalHash = $hashToKeys[$k];
+            $loadedKeys[$originalHash] = $k;
+            unset($hashToKeys[$k]);
             $this->rawTags(array_keys($tv->tags));
         }
         $this->tree->addToCache($validValues);
-        return $loadedKeys;
+        return new Result($loadedKeys, array_flip($hashToKeys));
     }
 
     /**

--- a/src/TTCache.php
+++ b/src/TTCache.php
@@ -193,7 +193,7 @@ class TTCache
         $validValues = $this->cache->getMultiple($hkeys);
         foreach ($validValues as $k => $tv) {
             $originalKey = $hashedKeysToOrigKeys[$k];
-            $loadedKeys[$originalKey] = $k;
+            $loadedKeys[$originalKey] = $keys[$originalKey];
             unset($keys[$originalKey]);
             $this->rawTags(array_keys($tv->tags));
         }

--- a/src/TTCache.php
+++ b/src/TTCache.php
@@ -190,7 +190,6 @@ class TTCache
         $hashedKeysToOrigKeys = array_flip($hkeys);
 
         $loadedKeys = [];
-        $missingKeys = $keys;
         $validValues = $this->cache->getMultiple($hkeys);
         foreach ($validValues as $k => $tv) {
             $originalKey = $hashedKeysToOrigKeys[$k];

--- a/src/TTCache.php
+++ b/src/TTCache.php
@@ -186,19 +186,20 @@ class TTCache
      */
     public function load(array $keys): Result
     {
-        $keys = array_combine($keys, $keys);
         $hkeys = array_map([$this, 'hashedKey'], $keys);
-        $hashToKeys = array_flip($hkeys);
+        $hashedKeysToOrigKeys = array_flip($hkeys);
+
         $loadedKeys = [];
+        $missingKeys = $keys;
         $validValues = $this->cache->getMultiple($hkeys);
         foreach ($validValues as $k => $tv) {
-            $originalHash = $hashToKeys[$k];
-            $loadedKeys[$originalHash] = $k;
-            unset($hashToKeys[$k]);
+            $originalKey = $hashedKeysToOrigKeys[$k];
+            $loadedKeys[$originalKey] = $k;
+            unset($keys[$originalKey]);
             $this->rawTags(array_keys($tv->tags));
         }
         $this->tree->addToCache($validValues);
-        return new Result($loadedKeys, array_flip($hashToKeys));
+        return new Result($loadedKeys, $keys);
     }
 
     /**

--- a/tests/TTCacheTest.php
+++ b/tests/TTCacheTest.php
@@ -498,13 +498,17 @@ abstract class TTCacheTest extends TestCase
         $store = new KeyTracker($origStore);
         $reflProperty->setValue($taggedStore, $store);
 
-        $built = fn() => $this->tt->remember('full-collection', null, [], function () use ($coll) {
+        $resultReaderStub = new class() {
+            public ?Result $result = null;
+        };
+
+        $built = fn() => $this->tt->remember('full-collection', null, [], function () use ($coll, $resultReaderStub) {
             $posts = [];
             $keys = [];
             foreach ($coll as $post) {
                 $keys[] = __CLASS__.':blog-collection:'.$post->id;
             }
-            $this->tt->load($keys);
+            $resultReaderStub->result = $this->tt->load($keys);
 
             foreach ($coll as $post) {
                 $key = __CLASS__.':blog-collection:'.$post->id;
@@ -513,7 +517,6 @@ abstract class TTCacheTest extends TestCase
 
             return $posts;
         });
-
 
         $this->assertEquals([
             "<h1>Learn PHP the curved way</h1><hr /><div>...</div>",
@@ -531,15 +534,29 @@ abstract class TTCacheTest extends TestCase
             'k-' . $this->hash('Square\TTCache\TTCacheTest:blog-collection:nop'),
         ], $store->requestedKeys);
 
+        $this->assertInstanceOf(Result::class, $resultReaderStub->result);
+        $this->assertEmpty($resultReaderStub->result->loadedKeys());
+        $this->assertEquals([
+            'Square\TTCache\TTCacheTest:blog-collection:abc',
+            'Square\TTCache\TTCacheTest:blog-collection:def',
+            'Square\TTCache\TTCacheTest:blog-collection:ghi',
+            'Square\TTCache\TTCacheTest:blog-collection:klm',
+            'Square\TTCache\TTCacheTest:blog-collection:nop',
+        ], $resultReaderStub->result->missingKeys());
+
         // When we call `built()` again, all the data should be pre-loaded and therefore come without talking to MC
+        $resultReaderStub->result = null;
         $store->requestedKeys = [];
         $built();
         $this->assertEquals([
             'k-' . $this->hash('full-collection'),
         ], $store->requestedKeys);
+        $this->assertNull($resultReaderStub->result);
+
 
         // Clear tag for "abc" and change the title for "abc"
         $this->tt->clearTags('post:'.$coll[0]->id);
+        $resultReaderStub->result = null;
         $store->requestedKeys = [];
         $coll[0]->title = 'Learn PHP the straight way';
         $this->assertEquals([
@@ -553,10 +570,23 @@ abstract class TTCacheTest extends TestCase
             'k-' . $this->hash('full-collection'),
             'k-' . $this->hash('Square\TTCache\TTCacheTest:blog-collection:abc'),
         ], $store->requestedKeys);
+        $this->assertInstanceOf(Result::class, $resultReaderStub->result);
+        $this->assertEquals([
+            1 => 'Square\TTCache\TTCacheTest:blog-collection:def',
+            2 => 'Square\TTCache\TTCacheTest:blog-collection:ghi',
+            3 => 'Square\TTCache\TTCacheTest:blog-collection:klm',
+            4 => 'Square\TTCache\TTCacheTest:blog-collection:nop',
+            /** @phpstan-ignore-next-line */
+        ], $resultReaderStub->result->loadedKeys());
+        $this->assertEquals([
+            0 => 'Square\TTCache\TTCacheTest:blog-collection:abc',
+            /** @phpstan-ignore-next-line */
+        ], $resultReaderStub->result->missingKeys());
 
         // Newly cached value still contains all the tags. So clearing by another tag will also work.
         $this->tt->clearTags('post:'.$coll[1]->id);
         $store->requestedKeys = [];
+        $resultReaderStub->result = null;
         $coll[1]->title = 'Learn Python the straight way';
         $this->assertEquals([
             "<h1>Learn PHP the straight way</h1><hr /><div>...</div>",
@@ -569,6 +599,18 @@ abstract class TTCacheTest extends TestCase
             'k-' . $this->hash('full-collection'),
             'k-' . $this->hash('Square\TTCache\TTCacheTest:blog-collection:def'),
         ], $store->requestedKeys);
+        $this->assertInstanceOf(Result::class, $resultReaderStub->result);
+        $this->assertEquals([
+            0 => 'Square\TTCache\TTCacheTest:blog-collection:abc',
+            2 => 'Square\TTCache\TTCacheTest:blog-collection:ghi',
+            3 => 'Square\TTCache\TTCacheTest:blog-collection:klm',
+            4 => 'Square\TTCache\TTCacheTest:blog-collection:nop',
+            /** @phpstan-ignore-next-line */
+        ], $resultReaderStub->result->loadedKeys());
+        $this->assertEquals([
+            1 => 'Square\TTCache\TTCacheTest:blog-collection:def',
+            /** @phpstan-ignore-next-line */
+        ], $resultReaderStub->result->missingKeys());
     }
 
     /**

--- a/tests/TTCacheTest.php
+++ b/tests/TTCacheTest.php
@@ -498,9 +498,9 @@ abstract class TTCacheTest extends TestCase
         $store = new KeyTracker($origStore);
         $reflProperty->setValue($taggedStore, $store);
 
-        $resultReaderStub = new class() {
-            public ?Result $result = null;
-        };
+        $resultReaderStub = (object) [
+            'result' => null,
+        ];
 
         $built = fn() => $this->tt->remember('full-collection', null, [], function () use ($coll, $resultReaderStub) {
             $posts = [];


### PR DESCRIPTION
When fetching valid cache entries for use in a cached collections, you may want to know which cache entries were found vs which cache entries weren't (or no longer valid). You may want to do this in order to load the missing entries from the DB at once via `WHERE ... IN (...)`, instead of querying individually – an N+1 anti-pattern – within the `remember(...)` clause.

```php

$ids = [...];
// Map of [<ID>] => cache key: "entity-[<ID>]"
$keys = collect(array_combine($ids, $ids))
   ->map(static fn($id) => 'entity-' . $id)
   ->toArray();

$result = $tt->load($keys);

// Map of [<ID>] => missing cache key: "entity-[<ID>]"
$missingKeys = $result->missingKeys();

$models = [];
if (!empty($missingKeys)) {
   $models = Entity::query()->whereIn('id', array_keys($missingKeys))
      ->get()
      ->keyBy('id');
}

$results = [];
foreach ($keys as $id => $cacheKey) {
     $results[$id] = $tt->remember($cachKey, 0, [], function () use ($models) {
          // Pulling from pre-loaded models from previous query. No N+1!
          $entity = $models[$id];
          return $this->serialize($model);
     });
}

```

---

Also proposing the addition of `TTCache#getLastResult(): Result` to inform callers whether or not the last `remember` call was a cache-hit or a cache-miss. This is something that can be useful for debugging, telemetry, that needs to happen _outside the callback function_.

For example, if you wish to add a HTTP header to tell whether or not the middleware-level cache was a hit or a miss:

```php

public function handle(Request $request, $next)
{
     $key = $request->uri();
     $response = $this->tt->remember($key, 0, [], function () use ($request, $next) {
         $response = $next($request);
         return $response->isSuccessful() ? $response : new BypassCache($response);
     });
     $result = $this->tt->getLastResult();
     // Set the header value to either a "hit" or "miss" depending on Result:
     $response->headers->set('x-ttcache-result', empty($result->loadedKeys()) ? 'miss' : 'hit');
     return $response;
}
```

@khepin Thoughts?



