### PR TITLE
Tests for retrieved tags propagation

### DIFF
--- a/tests/TTCacheTest.php
+++ b/tests/TTCacheTest.php
@@ -271,7 +271,6 @@ abstract class TTCacheTest extends TestCase
 
     /**
      * @test
-     * @group debug
      */
     function caching_from_a_cached_value_still_applies_inner_tags()
     {


### PR DESCRIPTION
Adds a test to assert that when an inner value is retrieved from cache,
its tags are still correctly propagated to the outer value currently
being computed.