### PR TITLE
Attach newly added tags to existing entries

### DIFF
--- a/tests/TTCacheTest.php
+++ b/tests/TTCacheTest.php
@@ -727,8 +727,7 @@ abstract class TTCacheTest extends TestCase
     {
         $v = $this->tt->remember('testkey', null, [], fn () => 'hello 1');
         $this->assertEquals('hello 1', $v->value());
-        // If we use the same key but a different callback that returns something different, we should still get
-        // the previously cached value.
+        // If we add "foobar" as a new tag value, it should re-use what was cached because the cache key didn't change.
         $v = $this->tt->remember('testkey', null, ['foobar'], fn () => 'hello 2');
         $this->assertTrue($v->isHit());
         $this->assertEquals('hello 1', $v->value());
@@ -742,12 +741,12 @@ abstract class TTCacheTest extends TestCase
     {
         $v = $this->tt->remember('testkey', null, ['baz'], fn () => 'hello 1');
         $this->assertEquals('hello 1', $v->value());
-        // If we use the same key but a different callback that returns something different, we should still get
-        // the previously cached value.
+        // If we add "foobar" as a new tag value, it should re-use what was cached because the cache key didn't change.
         $v = $this->tt->remember('testkey', null, ['baz', 'foobar'], fn () => 'hello 2');
         $this->assertTrue($v->isHit());
         $this->assertEquals('hello 1', $v->value());
 
+        // We should now be able to invalidate "foobar" and actually clear "testkey"
         $this->tt->clearTags('foobar');
         $v = $this->tt->remember('testkey', null, ['baz', 'foobar'], fn () => 'hello 2');
         $this->assertTrue($v->isMiss());


### PR DESCRIPTION
Currently, adding a new tag (e.g. `foobar`) to an existing `->remember(...)` call does either of the two:

1. If `$key` already exists, it doesn't do anything.
2. If `$key` does not exist/deemed invalid, the new value will get the new tag `foobar`.

Therefore clearing `foobar` would only invalidate entries created during (2). Understandable, but may not be intuitive.

I propose adding new tags to existing entries, this way reseting tags that weren't there from the beginning works more consistently.

I don't think this works w/ heritable tags, though. I haven't come up with any way to address that yet.

This would also be useful for cases where you realize later on that you have insufficient tagging & would like to backfill _and_ clear. You can add a "poison" tag to a portion of your tree then clear that.

---

On a similar note, I think removing tags should also be handled. Imagine removing the tag `foobar` from 1 out of 3 usages: Things will still come from cache, which is great. But resetting the `foobar` tag will clear all three places, even though 1 of them don't have it in `->remember(...)` call anymore.

