### PR TITLE
Open up the hashing method to external callers

### DIFF
--- a/tests/TTCacheTest.php
+++ b/tests/TTCacheTest.php
@@ -722,6 +722,16 @@ abstract class TTCacheTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function tag_hashes_match()
+    {
+        $tags = ['tag', 'other:tag'];
+        $r = $this->tt->remember('testkey', fn () => 'hello 1', $tags);
+        $this->assertSame($r->tags(), $this->tt->hashTags(...$tags));
+    }
+
+    /**
      * The hashing function being used in tests. Using the default here, which is md5 (https://www.php.net/manual/en/function.md5.php)
      */
     protected function hash(string $key): string


### PR DESCRIPTION
Internally, TTCache hashes the tags, however sometimes it is useful for external callers to retrieve those hashes based on the original tags as they may have been used for other purposes.

For example, using them as SurrogateKeys with CDNs.